### PR TITLE
Filter out old jobs from requests and prevent n+1 query for fetching job tags

### DIFF
--- a/backend/app/controllers/jobs_controller.rb
+++ b/backend/app/controllers/jobs_controller.rb
@@ -7,7 +7,7 @@ class JobsController < ApplicationController
   # GET /jobs
   # GET /jobs.json
   def index
-    @jobs = Job.where("jobs.end >= ? OR jobs.end IS NULL", Date.today)
+    @jobs = Job.where("jobs.end >= ? OR jobs.end IS NULL", Date.today).includes(:tags)
   end
 
   # GET /jobs/1

--- a/backend/app/controllers/jobs_controller.rb
+++ b/backend/app/controllers/jobs_controller.rb
@@ -7,7 +7,7 @@ class JobsController < ApplicationController
   # GET /jobs
   # GET /jobs.json
   def index
-    @jobs = Job.all
+    @jobs = Job.where("end >= ?", Date.today)
   end
 
   # GET /jobs/1

--- a/backend/app/controllers/jobs_controller.rb
+++ b/backend/app/controllers/jobs_controller.rb
@@ -7,7 +7,7 @@ class JobsController < ApplicationController
   # GET /jobs
   # GET /jobs.json
   def index
-    @jobs = Job.where("end >= ? OR end IS NULL", Date.today)
+    @jobs = Job.where("jobs.end >= ? OR jobs.end IS NULL", Date.today)
   end
 
   # GET /jobs/1

--- a/backend/app/controllers/jobs_controller.rb
+++ b/backend/app/controllers/jobs_controller.rb
@@ -7,7 +7,7 @@ class JobsController < ApplicationController
   # GET /jobs
   # GET /jobs.json
   def index
-    @jobs = Job.where("end >= ?", Date.today)
+    @jobs = Job.where("end >= ? OR end IS NULL", Date.today)
   end
 
   # GET /jobs/1


### PR DESCRIPTION
As quick patch only. Due to front-end limitations makes it also impossible to list expired jobs.